### PR TITLE
Edit the version of something you clicked

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -126,7 +126,7 @@
             <tbody>
               <tr><th colspan="{{nCols}}" id="favorites"><h2>Favorite Puzzles</h2></th></tr>
               {{#each faves}}
-                {{>blackboard_puzzle _id=_id puzzle=this}}
+                {{>blackboard_puzzle _id=_id parent="favorites" puzzle=this}}
               {{/each}}
             </tbody>
           {{/if}}
@@ -152,9 +152,9 @@
 <template name="blackboard_round">
   <tbody>
   <tr><th colspan="{{nCols}}" id="round{{_id}}">
-    <h2 class="bb-editable" data-bbedit="rounds/{{_id}}/title">
-    {{#if editing "rounds" _id "title"}}
-      <input type="text" id="rounds-{{_id}}-title"
+    <h2 class="bb-editable" data-bbedit="rounds//{{_id}}/title">
+    {{#if editing "rounds" "" _id "title"}}
+      <input type="text" id="rounds--{{_id}}-title"
             value="{{name}}"
             class="input-block-level" />
     {{else}}
@@ -173,7 +173,7 @@
   {{#unless compactMode}}{{>blackboard_tags}}{{/unless}}
   {{>blackboard_link}}
   {{#if canEdit}}
-    <div class="bb-round-buttons" data-bbedit="rounds/{{_id}}">
+    <div class="bb-round-buttons" data-bbedit="rounds//{{_id}}">
       <div class="btn-group">
         <button class="btn btn-mini btn-inverse bb-add-meta">
           <i class="fas fa-plus"></i>
@@ -259,9 +259,9 @@
 
 <template name="blackboard_puzzle_cells">
 <td class="puzzle-name"><div>{{! div needed to establish relative pos }}
-  <div class="bb-editable bb-puzzle-title" data-bbedit="puzzles/{{puzzle._id}}/title">
-    {{#if editing "puzzles" puzzle._id "title"}}
-      <input type="text" id="puzzles-{{puzzle._id}}-title"
+  <div class="bb-editable bb-puzzle-title" data-bbedit="puzzles/{{parent}}/{{puzzle._id}}/title">
+    {{#if editing "puzzles" parent puzzle._id "title"}}
+      <input type="text" id="puzzles-{{parent}}-{{puzzle._id}}-title"
               value="{{puzzle.name}}"
               class="input-block-level" />
     {{else}}
@@ -297,9 +297,9 @@
         {{#each tags}}
         <tr>
           <td class="bb-editable"
-              data-bbedit="tags/{{id}}/{{canon}}/name">
-            {{#if editing "tags" id canon "name"}}
-              <input type="text" id="tags-{{id}}-{{canon}}-name"
+              data-bbedit="tags/{{../../parent}}/{{id}}/{{canon}}/name">
+            {{#if editing "tags" ../../parent id canon "name"}}
+              <input type="text" id="tags-{{../../parent}}-{{id}}-{{canon}}-name"
                       value="{{name}}"
                       class="input-block-level" />
             {{else}}
@@ -311,17 +311,17 @@
             {{/if}}
           </td>
           <td class="bb-editable"
-              data-bbedit="tags/{{id}}/{{canon}}/value">
+              data-bbedit="tags/{{../../parent}}/{{id}}/{{canon}}/value">
             {{#if equal canon "color"}}
               {{#if canEdit}}
-                <input type="color" id="tags-{{id}}-{{canon}}-color"
+                <input type="color" id="tags-{{../../parent}}-{{id}}-{{canon}}-color"
                        value="{{hexify value}}" />
               {{else}}
                 <span class="bb-colorbox" style="background-color: {{value}}"></span>
               {{/if}}
             {{/if}}
-            {{#if editing "tags" id canon "value"}}
-              <input type="text" id="tags-{{id}}-{{canon}}-value"
+            {{#if editing "tags" ../../parent id canon "value"}}
+              <input type="text" id="tags-{{../../parent}}-{{id}}-{{canon}}-value"
                       value="{{value}}"
                       class="input-block-level" />
             {{else if canEdit}}
@@ -345,8 +345,8 @@
           {{/if}}
           <tr>
             <td>Feeds Into:</td>
-            <td class="bb-editable" data-bbedit="feedsInto/{{_id}}">
-              {{#if editing "feedsInto" _id}}
+            <td class="bb-editable" data-bbedit="feedsInto/{{../parent}}/{{_id}}">
+              {{#if editing "feedsInto" ../parent _id}}
                 {{#each allMetas}}{{> blackboard_unfeed_meta puzzle=.. meta=this}}{{/each}}
                 {{#with unfedMetas}}{{#if this.count}}
                   <div class="btn-group bb-feed-meta">
@@ -389,9 +389,9 @@
     {{/with}}
   </div></td>
   <td class="puzzle-answer bb-editable"
-      data-bbedit="tags/{{puzzle._id}}/answer/value">
-    {{#if editing "tags" puzzle._id "answer" "value"}}
-      <input type="text" id="tags-{{puzzle._id}}-answer-value"
+      data-bbedit="tags/{{parent}}/{{puzzle._id}}/answer/value">
+    {{#if editing "tags" parent puzzle._id "answer" "value"}}
+      <input type="text" id="tags-{{parent}}-{{puzzle._id}}-answer-value"
               value="{{tag "answer"}}"
               class="input-block-level" />
     {{else}}
@@ -409,10 +409,11 @@
     {{/if}}
   </td>
   {{#unless compactMode}}
+    
     <td class="puzzle-status {{#unless puzzle.solved}}bb-editable{{/unless}}"
-        data-bbedit="tags/{{puzzle._id}}/status/value">
-      {{#if editing "tags" puzzle._id "status" "value"}}
-        <input type="text" id="tags-{{puzzle._id}}-status-value"
+        data-bbedit="tags/{{parent}}/{{puzzle._id}}/status/value">
+      {{#if editing "tags" parent puzzle._id "status" "value"}}
+        <input type="text" id="tags-{{parent}}-{{puzzle._id}}-status-value"
                 value="{{tag "status"}}"
                 class="input-block-level" />
       {{else}}
@@ -465,13 +466,13 @@
       {{> blackboard_puzzle_cells}}
     </tr>
     {{#each puzzles}}
-      {{> blackboard_puzzle}}
+      {{> blackboard_puzzle }}
     {{else unless num_puzzles}}
       <tr class="round-empty"><td colspan="{{nCols}}">No puzzles feed this meta yet.</td></tr>
     {{/each}}
   {{#if canEdit}}
   <tr class="metafooter"><td colspan="{{nCols}}">
-    <div class="bb-meta-buttons" data-bbedit="puzzles/{{puzzle._id}}">
+    <div class="bb-meta-buttons" data-bbedit="puzzles/{{parent}}/{{puzzle._id}}">
       <button class="btn btn-mini btn-inverse bb-add-puzzle">
         <i class="fas fa-plus"></i>
         Create new puzzle feeding this meta
@@ -501,9 +502,9 @@
 <template name="blackboard_tags">
   <dl class="dl-horizontal">{{#each tags}}
     <dt class="bb-editable"
-        data-bbedit="tags/{{id}}/{{canon}}/name">
-      {{#if editing "tags" id canon "name"}}
-        <input type="text" id="tags-{{id}}-{{canon}}-name"
+        data-bbedit="tags/{{../parent}}/{{id}}/{{canon}}/name">
+      {{#if editing "tags" ../parent id canon "name"}}
+        <input type="text" id="tags-{{../parent}}-{{id}}-{{canon}}-name"
                value="{{name}}"
                class="input-block-level" />
       {{else}}
@@ -515,9 +516,9 @@
       {{/if}}
      </dt>
     <dd class="bb-editable"
-        data-bbedit="tags/{{id}}/{{canon}}/value">
-      {{#if editing "tags" id canon "value"}}
-        <input type="text" id="tags-{{id}}-{{canon}}-value"
+        data-bbedit="tags/{{../parent}}/{{id}}/{{canon}}/value">
+      {{#if editing "tags" ../parent id canon "value"}}
+        <input type="text" id="tags-{{../parent}}-{{id}}-{{canon}}-value"
                value="{{value}}"
                class="input-block-level" />
       {{else if canEdit}}
@@ -541,9 +542,9 @@
         <tr>
           <td>Hunt site link:</td>
           <td class="bb-editable"
-              data-bbedit="link/{{_id}}">
-            {{#if editing "link" _id}}
-              <input type="text" id="link-{{_id}}"
+              data-bbedit="link/{{parent}}/{{_id}}">
+            {{#if editing "link" parent _id}}
+              <input type="text" id="link-{{parent}}-{{_id}}"
                      value="{{./link}}"
                      class="input-block-level" />
             {{else if canEdit}}

--- a/blackboard.html
+++ b/blackboard.html
@@ -539,21 +539,21 @@
 <template name="blackboard_link">
 {{#if canEdit}}
   <table class="bb-tag-table"><tbody>
-        <tr>
-          <td>Hunt site link:</td>
-          <td class="bb-editable"
-              data-bbedit="link/{{parent}}/{{_id}}">
-            {{#if editing "link" parent _id}}
-              <input type="text" id="link-{{parent}}-{{_id}}"
-                     value="{{./link}}"
-                     class="input-block-level" />
-            {{else if canEdit}}
-              <i class="bb-edit-icon fas fa-pencil-alt pull-right"
-                 title="Change the value of the hunt site link"></i>
-              <a href="{{./link}}">{{./link}}</a>
-            {{/if}}
-          </td>
-        </tr>
+    <tr>
+      <td>Hunt site link:</td>
+      <td class="bb-editable"
+          data-bbedit="link/{{../parent}}/{{_id}}">
+        {{#if editing "link" ../parent _id}}
+          <input type="text" id="link-{{../parent}}-{{_id}}"
+                  value="{{./link}}"
+                  class="input-block-level" />
+        {{else if canEdit}}
+          <i class="bb-edit-icon fas fa-pencil-alt pull-right"
+              title="Change the value of the hunt site link"></i>
+          <a href="{{./link}}">{{./link}}</a>
+        {{/if}}
+      </td>
+    </tr>
   </tbody></table>
 {{/if}}
 </template>

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -148,6 +148,7 @@ meta_helper = ->
     continue unless puzzle?
     {
       _id: id
+      parent: @_id
       puzzle: puzzle
       num_puzzles: puzzle.puzzles.length
     }
@@ -156,7 +157,7 @@ unassigned_helper = ->
   p = for id, index in this.puzzles
     puzzle = model.Puzzles.findOne({_id: id, feedsInto: {$size: 0}, puzzles: {$exists: false}})
     continue unless puzzle?
-    { _id: id, puzzle: puzzle }
+    { _id: id, parent: @_id, puzzle: puzzle }
   editing = Meteor.userId() and (Session.get 'canEdit')
   hideSolved = 'true' is reactiveLocalStorage.getItem 'hideSolved'
   return p if editing or !hideSolved
@@ -276,7 +277,7 @@ Template.blackboard.events
       Meteor.call 'setTag', {type:'puzzles', object: @puzzle._id, name:str, value:''}
   "click .bb-canEdit .bb-delete-icon": (event, template) ->
     event.stopPropagation() # keep .bb-editable from being processed!
-    [type, id, rest...] = share.find_bbedit(event)
+    [type, _parent, id, rest...] = share.find_bbedit(event)
     message = "Are you sure you want to delete "
     if (type is'tags') or (rest[0] is 'title')
       message += "this #{model.pretty_collection(type)}?"
@@ -296,7 +297,7 @@ Template.blackboard.events
     event.stopPropagation()
   'input input[type=color]': (event, template) ->
     edit = $(event.currentTarget).closest('*[data-bbedit]').attr('data-bbedit')
-    [type, id, rest...] = edit.split('/')
+    [type, _parent, id, rest...] = edit.split('/')
     # strip leading/trailing whitespace from text (cancel if text is empty)
     text = hexToCssColor event.currentTarget.value.replace /^\s+|\s+$/, ''
     processBlackboardEdit[type]?(text, id, rest...) if text
@@ -304,7 +305,7 @@ Template.blackboard.events okCancelEvents('.bb-editable input[type=text]',
   ok: (text, evt) ->
     # find the data-bbedit specification for this field
     edit = $(evt.currentTarget).closest('*[data-bbedit]').attr('data-bbedit')
-    [type, id, rest...] = edit.split('/')
+    [type, _parent, id, rest...] = edit.split('/')
     # strip leading/trailing whitespace from text (cancel if text is empty)
     text = text.replace /^\s+|\s+$/, ''
     processBlackboardEdit[type]?(text, id, rest...) if text
@@ -436,6 +437,7 @@ Template.blackboard_meta.helpers
   puzzles: ->
     p = ({
       _id: id
+      parent: @_id
       puzzle: model.Puzzles.findOne(id) or { _id: id }
     } for id, index in this.puzzle.puzzles)
     editing = Meteor.userId() and (Session.get 'canEdit')


### PR DESCRIPTION
Since some things can appear multiple times (metas that feed metametas, leaves that feed multiple metas, or favorite puzzles), when you click something to edit it, focus the copy you clicked, not the first one on the page.
Fixes #19 