### PR TITLE
Allow ordering puzzles in a meta alphabetically

### DIFF
--- a/blackboard.html
+++ b/blackboard.html
@@ -343,6 +343,19 @@
             <td><input class="bb-set-is-meta" type="checkbox" checked={{isMeta}} /></td>
           </tr>
           {{/if}}
+          {{#if isMeta}}
+          <tr>
+            <td>Sort Order:</td>
+            <td><div class="btn-group bb-puzzle-order">
+              <button class="btn btn-mini {{#unless order_by}}active{{/unless}}" data-sort-order="" title="Manual">
+                <i class="fas fa-exchange-alt fa-rotate-90"></i>
+              </button>
+              <button class="btn btn-mini {{#if equal order_by "name"}}active{{/if}}" data-sort-order="name" title="Alphabetical">
+                <i class="fas fa-sort-alpha-down"></i>
+              </button>
+            </div></td>
+          </tr>
+          {{/if}}
           <tr>
             <td>Feeds Into:</td>
             <td class="bb-editable" data-bbedit="feedsInto/{{../parent}}/{{_id}}">
@@ -465,11 +478,13 @@
     <tr class="meta {{#if stuck puzzle}}bb-status-stuck{{/if}}">
       {{> blackboard_puzzle_cells}}
     </tr>
-    {{#each puzzles}}
-      {{> blackboard_puzzle }}
-    {{else unless num_puzzles}}
-      <tr class="round-empty"><td colspan="{{nCols}}">No puzzles feed this meta yet.</td></tr>
-    {{/each}}
+    {{#if any canEdit (not collapsed)}}
+      {{#each p in puzzles}}
+        {{> blackboard_puzzle _id=p._id puzzle=p.puzzle draggable=(not puzzle.order_by)}}
+      {{else unless num_puzzles}}
+        <tr class="round-empty"><td colspan="{{nCols}}">No puzzles feed this meta yet.</td></tr>
+      {{/each}}
+    {{/if}}
   {{#if canEdit}}
   <tr class="metafooter"><td colspan="{{nCols}}">
     <div class="bb-meta-buttons" data-bbedit="puzzles/{{parent}}/{{puzzle._id}}">
@@ -494,7 +509,7 @@
 </template>
 
 <template name="blackboard_puzzle">
-  <tr class="puzzle {{#if stuck puzzle}}bb-status-stuck{{/if}}" draggable="{{canEdit}}" data-puzzle-id="{{puzzle._id}}">
+  <tr class="puzzle {{#if stuck puzzle}}bb-status-stuck{{/if}}" draggable="{{all canEdit draggable}}" data-puzzle-id="{{puzzle._id}}">
     {{> blackboard_puzzle_cells}}
  </tr>
 </template>

--- a/client/blackboard.coffee
+++ b/client/blackboard.coffee
@@ -433,8 +433,15 @@ Template.blackboard_meta.events
 Template.blackboard_meta.helpers
   color: -> puzzleColor @puzzle if @puzzle?
   showMeta: -> ('true' isnt reactiveLocalStorage.getItem 'hideSolvedMeta') or (!this.puzzle?.solved?)
-  # the following is a map() instead of a direct find() to preserve order
   puzzles: ->
+    if @puzzle.order_by
+      filter =
+        feedsInto: @puzzle._id
+      if not (Session.get 'canEdit') and 'true' is reactiveLocalStorage.getItem 'hideSolved'
+        filter.solved = $eq: null
+      return model.Puzzles.find filter,
+        sort: {"#{@puzzle.order_by}": 1}
+        transform: (p) -> {_id: p._id, puzzle: p}
     p = ({
       _id: id
       parent: @_id
@@ -469,6 +476,11 @@ Template.blackboard_puzzle_cells.events
   'click .bb-feed-meta a[data-puzzle-id]': (event, template) ->
     Meteor.call 'feedMeta', template.data.puzzle._id, event.target.dataset.puzzleId
     event.preventDefault()
+  'click button[data-sort-order]': (event, template) ->
+    Meteor.call 'setField',
+      type: 'puzzles'
+      object: template.data.puzzle._id
+      fields: order_by: event.currentTarget.dataset.sortOrder
 
 tagHelper = ->
   isRound = not ('feedsInto' of this)

--- a/client/main.coffee
+++ b/client/main.coffee
@@ -20,6 +20,12 @@ chat = share.chat # import
 #   "quips"      -- view/edit phone-answering quips
 #   "facts"      -- server performance information
 Template.registerHelper "equal", (a, b) -> a is b
+Template.registerHelper "less", (a, b) -> a < b
+Template.registerHelper 'any', (a..., options) ->
+  a.some (x) -> x
+Template.registerHelper 'all', (a..., options) ->
+  a.every (x) -> x
+Template.registerHelper 'not', (a) -> not a
 
 # session variables we want to make available from all templates
 do -> for v in ['currentPage']

--- a/lib/model.coffee
+++ b/lib/model.coffee
@@ -98,6 +98,9 @@ if Meteor.isServer
 #   puzzles: array of puzzle _ids for puzzles that feed into this.
 #            absent if this isn't a meta. empty if it is, but nothing feeds into
 #            it yet.
+#   order_by: If this is a meta, how to sort puzzles in it.
+#     If unset/empty, use the order in the puzzles array.
+#     If 'name', alphabetically by name
 #   feedsInto: array of puzzle ids for metapuzzles this feeds into. Can be empty.
 #   if a has b in its feedsInto, then b should have a in its puzzles.
 #   This is kept denormalized because the lack of indexes in Minimongo would
@@ -1053,6 +1056,8 @@ doc_id_to_link = (id) ->
                'located','located_at',
                'priv_located','priv_located_at','priv_located_order']
         delete args.fields[f]
+      if args.fields.order_by
+        check args.fields.order_by, Match.OneOf EqualsString(''), EqualsString('name')
       args.fields.touched = now
       args.fields.touched_by = @userId
       collection(args.type).update id, $set: args.fields

--- a/server/server.coffee
+++ b/server/server.coffee
@@ -22,6 +22,7 @@ puzzleQuery = (query) ->
       "favorites.#{@userId}": 1
       mechanics: 1
       puzzles: 1
+      order_by: 1
       feedsInto: 1
 
 loginRequired = (f) -> ->


### PR DESCRIPTION
* Allow ordering puzzles in a meta alphabetically

It disables the ability to drag and drop.

* Fix filtering of solved puzzles

Fixes #26 